### PR TITLE
Bump base64 to 0.21

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2021"
 
 [dependencies]
 anyhow = "1"
-base64 = { version = "0.13.0", default-features = false }
+base64 = { version = "0.21.0", default-features = false }
 err-derive = "0.2"
 log = "0.4.13"
 reqwest = { version = "0.11", default-features = false, features = ["blocking", "multipart"] }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,7 +10,7 @@
 //! information on licensing and copyright.
 
 use anyhow::{anyhow, Result as AnyhowResult};
-use base64;
+use base64::{Engine, engine::general_purpose::STANDARD as b64_engine};
 use err_derive::Error;
 use log::{error, info};
 use std::collections::HashMap;
@@ -74,8 +74,8 @@ pub fn complete_proxy_attestation_nitro(
 ) -> AnyhowResult<Vec<u8>> {
     let url = format!("http://{:}/proxy/v1/Nitro/{:}", proxy_attestation_server_url, challenge_id);
     let mut form_fields: HashMap<String, String> = HashMap::new();
-    form_fields.insert("token".to_string(), base64::encode(att_doc));
-    form_fields.insert("csr".to_string(), base64::encode(csr));
+    form_fields.insert("token".to_string(), b64_engine.encode(att_doc));
+    form_fields.insert("csr".to_string(), b64_engine.encode(csr));
 
     let response = http::post_form(url, &form_fields)
         .map_err(|err| ProxyAttestationClientError::HttpError(err))?;
@@ -93,8 +93,8 @@ pub fn complete_proxy_attestation_linux(
 ) -> AnyhowResult<Vec<u8>> {
     let url = format!("http://{:}/proxy/v1/PSA/{:}", proxy_attestation_server_url, challenge_id);
     let mut form_fields: HashMap<String, String> = HashMap::new();
-    form_fields.insert("token".to_string(), base64::encode(token));
-    form_fields.insert("csr".to_string(), base64::encode(csr));
+    form_fields.insert("token".to_string(), b64_engine.encode(token));
+    form_fields.insert("csr".to_string(), b64_engine.encode(csr));
 
     let response = http::post_form(url, &form_fields)
         .map_err(|err| ProxyAttestationClientError::HttpError(err))?;


### PR DESCRIPTION
proxy-attestation-client doesn't build anymore:
```
error[E0423]: expected function, found module `base64::encode`
  --> src/lib.rs:77:45
   |
77 |     form_fields.insert("token".to_string(), base64::encode(att_doc));
   |                                             ^^^^^^^^^^^^^^ not a function
```